### PR TITLE
Reinitialization was needed after firmwareupgrade

### DIFF
--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -508,6 +508,9 @@
 - (void)clearDfuHandlers {
     dfuCallbackId = nil;
     dfuController = nil;
+
+    // Reinitialize
+    [self pluginInitialize];
 }
 
 - (void)onReset {


### PR DESCRIPTION
I now have working firmware upgrade functionality that continues to work on IOS after the upgrade...

BR Flemming