### PR TITLE
framework iOSDFULibrary - update version to 4.1.2

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,7 +38,7 @@
 
         <!-- frameworks -->
         <framework src="CoreBluetooth.framework" />
-        <framework src="iOSDFULibrary" type="podspec" spec="~> 3.0.6"/>
+        <framework src="iOSDFULibrary" type="podspec" spec="~> 4.1.2"/>
 
         <hook type="before_plugin_install" src="hooks/ios_pod_extra_settings.js" />
 


### PR DESCRIPTION
In iOS 11 there are changes to the zip library, which leads to the app crashing due to an unhandled error in the iOSDFULibrary. Upgrading to > v4 corrects the issue.

More information: https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/issues/143