### PR TITLE
Update iOSDFULibrary version to 4.12.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -37,7 +37,7 @@
 
         <!-- frameworks -->
         <framework src="CoreBluetooth.framework" />
-        <framework src="iOSDFULibrary" type="podspec" spec="~> 4.1.2"/>
+        <framework src="iOSDFULibrary" type="podspec" spec="~> 4.12.0"/>
 
         <hook type="before_plugin_install" src="hooks/ios_pod_extra_settings.js" />
 


### PR DESCRIPTION
See [iOSDFULibrary needs to be updated to fix errors related to unwrapping optionals](https://github.com/fxe-gear/cordova-plugin-ble-central/issues/11)

@tomasbedrich, can you merge this change? I was able to verify the issue is fixed after updating plugin.xml to iOSDFULibrary version to 4.12.0.